### PR TITLE
fix: include hidden files in file search

### DIFF
--- a/widgets/fzf-file-widget.zsh
+++ b/widgets/fzf-file-widget.zsh
@@ -1,5 +1,5 @@
 fzf_find_files() {
-	fd $FZF_FD_OPTS --type file --color=always
+	fd $FZF_FD_OPTS --hidden --type file --color=always
 }
 
 # File search using fzf

--- a/widgets/fzf-file-widget.zsh
+++ b/widgets/fzf-file-widget.zsh
@@ -1,5 +1,5 @@
 fzf_find_files() {
-	fd $FZF_FD_OPTS --hidden --type file --color=always
+	fd $FZF_FD_OPTS --hidden --exclude .git --exclude .hg --exclude .svn --type file --color=always
 }
 
 # File search using fzf


### PR DESCRIPTION
## Summary
- include hidden files in file search by adding `--hidden` to fd

## Testing
- zsh -n fzf.plugin.zsh widgets/*.zsh